### PR TITLE
Adding support for GET parameters.

### DIFF
--- a/config/local_json.go
+++ b/config/local_json.go
@@ -30,9 +30,9 @@ type MetricsDBSubConfig struct {
 }
 
 type ProberContextSubConfig struct {
-	Url        string      `json:"url"`
-	Method     string      `json:"method"`
-	Parameters interface{} `json:"parameters"`
+	Url               string            `json:"url"`
+	Method            string            `json:"method"`
+	RequestParameters map[string]string `json:"parameters"`
 }
 
 // ProberSubConfig holds configuration of each prober.

--- a/probers/generic_prober.go
+++ b/probers/generic_prober.go
@@ -34,8 +34,9 @@ func NewProber(c config.ProberSubConfig) (Prober, error) {
 	switch c.Name {
 	case "basic_http_prober":
 		newProber = &HTTPProber{
-			Url:    c.Context.Url,
-			Method: c.Context.Method,
+			Url:        c.Context.Url,
+			Method:     c.Context.Method,
+			Parameters: c.Context.RequestParameters,
 		}
 		break
 	default:

--- a/probers/http_prober.go
+++ b/probers/http_prober.go
@@ -7,6 +7,7 @@ import (
 	"inspector/mylogger"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -67,9 +68,17 @@ func (httpProber *HTTPProber) RunOnce(c chan metrics.SingleMetric) error {
 	var response *http.Response
 	var err error
 	var start time.Time
+
+	params := url.Values{}
+	for name, value := range httpProber.Parameters {
+		params.Add(name, value)
+	}
+	baseURL, _ := url.Parse(httpProber.Url)
+	baseURL.RawQuery = params.Encode()
+
 	if httpProber.Method == "GET" {
 		start = time.Now()
-		response, err = httpProber.client.Get(httpProber.Url)
+		response, err = httpProber.client.Get(baseURL.String())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
GET parameters now actually work.
Parameters can either be spelled out in the "parameters" section of the config or just added inline in the URL. 