### PR TITLE
Cookies & redirect support in http prober.

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,8 +35,12 @@
             {
               "param1": "foo",
               "param2": "bar"
+            },
+            "cookies":
+            {
+              "name": "value"
             }
-          } 
+          }
         },
         {
           "id": "2",

--- a/config.json
+++ b/config.json
@@ -39,7 +39,8 @@
             "cookies":
             {
               "name": "value"
-            }
+            },
+            "allow_redirects": false
           }
         },
         {

--- a/config/local_json.go
+++ b/config/local_json.go
@@ -35,6 +35,8 @@ type ProberContextSubConfig struct {
 	RequestParameters map[string]string `json:"parameters"`
 	// Holds the list of cookies
 	Cookies map[string]string `json:"cookies"`
+	// Whether to follow http redirects from the server or not. Empty stanza uses the default 10 level redirect limit.
+	AllowRedirects bool `json:"allow_redirects,omitempty"`
 }
 
 // ProberSubConfig holds configuration of each prober.

--- a/config/local_json.go
+++ b/config/local_json.go
@@ -33,6 +33,8 @@ type ProberContextSubConfig struct {
 	Url               string            `json:"url"`
 	Method            string            `json:"method"`
 	RequestParameters map[string]string `json:"parameters"`
+	// Holds the list of cookies
+	Cookies map[string]string `json:"cookies"`
 }
 
 // ProberSubConfig holds configuration of each prober.

--- a/probers/generic_prober.go
+++ b/probers/generic_prober.go
@@ -37,6 +37,7 @@ func NewProber(c config.ProberSubConfig) (Prober, error) {
 			Url:        c.Context.Url,
 			Method:     c.Context.Method,
 			Parameters: c.Context.RequestParameters,
+			Cookies:    c.Context.Cookies,
 		}
 		break
 	default:

--- a/probers/generic_prober.go
+++ b/probers/generic_prober.go
@@ -34,10 +34,11 @@ func NewProber(c config.ProberSubConfig) (Prober, error) {
 	switch c.Name {
 	case "basic_http_prober":
 		newProber = &HTTPProber{
-			Url:        c.Context.Url,
-			Method:     c.Context.Method,
-			Parameters: c.Context.RequestParameters,
-			Cookies:    c.Context.Cookies,
+			Url:            c.Context.Url,
+			Method:         c.Context.Method,
+			Parameters:     c.Context.RequestParameters,
+			Cookies:        c.Context.Cookies,
+			AllowRedirects: c.Context.AllowRedirects,
 		}
 		break
 	default:


### PR DESCRIPTION
Cookies can now be defined in the config to monitoring authenticated endpoints.
Added a simple knob controlling how redirects are handled: if disabled then the redirect status is returned, otherwise a 10 level deep redirect limit is applied.